### PR TITLE
usb_protocol.types.USBPacketID: fix .byte() type

### DIFF
--- a/usb_protocol/types/__init__.py
+++ b/usb_protocol/types/__init__.py
@@ -197,8 +197,8 @@ class USBPacketID(IntFlag):
     def byte(self):
         """ Return the PID's value with its upper nibble. """
 
-        inverted_pid = self ^ 0b1111
-        full_pid     = (inverted_pid << 4) | self
+        inverted_pid = int(self) ^ 0b1111
+        full_pid     = (inverted_pid << 4) | int(self)
 
         return full_pid
 


### PR DESCRIPTION
Make `USBPacketID.byte()` method return an `int` instead of a `USBPacketID`.
Related to https://github.com/greatscottgadgets/luna/issues/198