### PR TITLE
Add HID classes

### DIFF
--- a/usb_protocol/emitters/descriptors/hid.py
+++ b/usb_protocol/emitters/descriptors/hid.py
@@ -11,19 +11,19 @@ class HIDDescriptorEmitter(ComplexDescriptorEmitter):
     DESCRIPTOR_FORMAT = HIDDescriptor
     
     @contextmanager
-    def ReportDescriptor(self):
+    def DescriptorReference(self):
         """ Context manager that allows addition of a subordinate report descriptor.
 
-        It can be used with a `with` statement; and yields an HIDReportDescriptorEmitter
+        It can be used with a `with` statement; and yields an HIDDescriptorReferenceEmitter
         that can be populated:
 
-            with hiddescriptor.ReportDescriptor() as r:
+            with hiddescriptor.DescriptorReference() as r:
                 r.wDescriptorLength = 0x10
 
         This adds the relevant descriptor, automatically.
         """
 
-        descriptor = HIDReportDescriptorEmitter()
+        descriptor = HIDDescriptorReferenceEmitter()
         yield descriptor
 
         self.add_subordinate_descriptor(descriptor)
@@ -36,4 +36,4 @@ class HIDDescriptorEmitter(ComplexDescriptorEmitter):
         pass
 
 
-HIDReportDescriptorEmitter = emitter_for_format(HIDReportDescriptor)
+HIDDescriptorReferenceEmitter = emitter_for_format(HIDDescriptorReference)

--- a/usb_protocol/emitters/descriptors/hid.py
+++ b/usb_protocol/emitters/descriptors/hid.py
@@ -1,0 +1,39 @@
+import unittest
+
+from contextlib import contextmanager
+
+from ..           import emitter_for_format
+from ..descriptor import ComplexDescriptorEmitter
+from ...types.descriptors.hid import *
+
+class HIDDescriptorEmitter(ComplexDescriptorEmitter):
+
+    DESCRIPTOR_FORMAT = HIDDescriptor
+    
+    @contextmanager
+    def ReportDescriptor(self):
+        """ Context manager that allows addition of a subordinate report descriptor.
+
+        It can be used with a `with` statement; and yields an HIDReportDescriptorEmitter
+        that can be populated:
+
+            with hiddescriptor.ReportDescriptor() as r:
+                r.wDescriptorLength = 0x10
+
+        This adds the relevant descriptor, automatically.
+        """
+
+        descriptor = HIDReportDescriptorEmitter()
+        yield descriptor
+
+        self.add_subordinate_descriptor(descriptor)
+
+    def _pre_emit(self):
+        # Figure out the total length of our descriptor, including subordinates.
+        subordinate_length = sum(len(sub) for sub in self._subordinates)
+        self.bLength = subordinate_length + self.DESCRIPTOR_FORMAT.sizeof()
+        self.bNumDescriptors = len(self._subordinates)
+        pass
+
+
+HIDReportDescriptorEmitter = emitter_for_format(HIDReportDescriptor)

--- a/usb_protocol/emitters/descriptors/hid.py
+++ b/usb_protocol/emitters/descriptors/hid.py
@@ -22,7 +22,7 @@ class HIDDescriptorEmitter(ComplexDescriptorEmitter):
                 r.wDescriptorLength = 0x10
                 r.wDescriptorLength = 0x10
 
-        This adds the relevant descriptor, automatically.
+        This adds the relevant descriptor reference, automatically.
         """
 
         descriptor = HIDDescriptorReferenceEmitter()

--- a/usb_protocol/emitters/descriptors/hid.py
+++ b/usb_protocol/emitters/descriptors/hid.py
@@ -18,6 +18,8 @@ class HIDDescriptorEmitter(ComplexDescriptorEmitter):
         that can be populated:
 
             with hiddescriptor.DescriptorReference() as r:
+                r.bDescriptorType = 0x22
+                r.wDescriptorLength = 0x10
                 r.wDescriptorLength = 0x10
 
         This adds the relevant descriptor, automatically.

--- a/usb_protocol/emitters/descriptors/hid.py
+++ b/usb_protocol/emitters/descriptors/hid.py
@@ -12,7 +12,7 @@ class HIDDescriptorEmitter(ComplexDescriptorEmitter):
     
     @contextmanager
     def DescriptorReference(self):
-        """ Context manager that allows addition of a subordinate report descriptor.
+        """ Context manager that allows addition of a descriptor reference.
 
         It can be used with a `with` statement; and yields an HIDDescriptorReferenceEmitter
         that can be populated:

--- a/usb_protocol/types/descriptors/hid.py
+++ b/usb_protocol/types/descriptors/hid.py
@@ -1,0 +1,33 @@
+#
+# This file is part of usb-protocol.
+#
+""" Structures describing Human Interface Device Class descriptors. """
+
+import unittest
+from enum import IntEnum
+
+from ..descriptor import \
+    DescriptorField, DescriptorNumber, DescriptorFormat
+
+class HidClassSpecificDescriptorTypes(IntEnum):
+    CS_UNDEFINED     = 0x20
+    CS_HID           = 0x21
+    CS_REPORT        = 0x22
+    CS_PHYSICAL      = 0x23
+
+
+HIDDescriptor = DescriptorFormat(
+    "bLength"             / DescriptorField("Descriptor Length"),
+    "bDescriptorType"     / DescriptorNumber(HidClassSpecificDescriptorTypes.CS_HID),
+    "bcdHID"              / DescriptorField("HID Protocol Version", default=1.11),
+    "bCountryCode"        / DescriptorField("Hardware target country", default=0),
+    "bNumDescriptors"     / DescriptorField("Number of HID class descriptors to follow", default=0),
+)
+
+# This is not reallyy a stand-alone descriptor, but it is part of the HIDDescriptor above.
+# That descriptor can contain multiple ReportDescriptors. To support this, a seperate
+# descriptor format is used.
+HIDReportDescriptor = DescriptorFormat(
+    "bDescriptorType"     / DescriptorField("HID Descriptor Type", default=HidClassSpecificDescriptorTypes.CS_REPORT),
+    "wDescriptorLength"   / DescriptorField("HID Descriptor Length")
+)

--- a/usb_protocol/types/descriptors/hid.py
+++ b/usb_protocol/types/descriptors/hid.py
@@ -9,6 +9,18 @@ from enum import IntEnum
 from ..descriptor import \
     DescriptorField, DescriptorNumber, DescriptorFormat
 
+class HidInterfaceClassCodes(IntEnum):
+    HID = 0x03
+
+class HidInterfaceSubclassCodes(IntEnum):
+    NO_SUBCLASS = 0
+    BOOT        = 1
+
+class HidInterfaceProtocols(IntEnum):
+    NONE     = 0
+    KEYBOARD = 1
+    MOUSE    = 2
+
 class HidClassSpecificDescriptorTypes(IntEnum):
     CS_UNDEFINED     = 0x20
     CS_HID           = 0x21

--- a/usb_protocol/types/descriptors/hid.py
+++ b/usb_protocol/types/descriptors/hid.py
@@ -36,10 +36,11 @@ HIDDescriptor = DescriptorFormat(
     "bNumDescriptors"     / DescriptorField("Number of HID class descriptors to follow", default=0),
 )
 
-# This is not reallyy a stand-alone descriptor, but it is part of the HIDDescriptor above.
-# That descriptor can contain multiple ReportDescriptors. To support this, a seperate
+# This is not really a stand-alone descriptor, but it it  is more a reference to a report 
+# descriptor that can retrieved seperately. It is part of the HIDDescriptor above. 
+# That descriptor can contain multiple descriptor references. To support this, a seperate
 # descriptor format is used.
-HIDReportDescriptor = DescriptorFormat(
+HIDDescriptorReference = DescriptorFormat(
     "bDescriptorType"     / DescriptorField("HID Descriptor Type", default=HidClassSpecificDescriptorTypes.CS_REPORT),
     "wDescriptorLength"   / DescriptorField("HID Descriptor Length")
 )

--- a/usb_protocol/types/descriptors/hid.py
+++ b/usb_protocol/types/descriptors/hid.py
@@ -36,9 +36,9 @@ HIDDescriptor = DescriptorFormat(
     "bNumDescriptors"     / DescriptorField("Number of HID class descriptors to follow", default=0),
 )
 
-# This is not really a stand-alone descriptor, but it it  is more a reference to a report 
-# descriptor that can retrieved seperately. It is part of the HIDDescriptor above. 
-# That descriptor can contain multiple descriptor references. To support this, a seperate
+# This is not really a stand-alone descriptor, but rather a reference to a descriptor
+# that can be retrieved seperately. It is part of the HIDDescriptor above.  The HID
+# descriptor can contain multiple descriptor references. To support this, a separate
 # descriptor format is used.
 HIDDescriptorReference = DescriptorFormat(
     "bDescriptorType"     / DescriptorField("HID Descriptor Type", default=HidClassSpecificDescriptorTypes.CS_REPORT),


### PR DESCRIPTION
Add support for HID class specific descriptors. This is different from #6, as it doesn't include the actual HID report itself. It is assumed that that is already known or created using a different tool.