### PR TITLE
midi1: Add the ability to specify iJack

### DIFF
--- a/usb_protocol/emitters/descriptors/midi1.py
+++ b/usb_protocol/emitters/descriptors/midi1.py
@@ -28,8 +28,17 @@ class MidiOutJackDescriptorEmitter(ComplexDescriptorEmitter):
         sourceDescriptor.BaSourcePin = sourcePin
         self.add_subordinate_descriptor(sourceDescriptor)
 
+    def __setattr__(self, name, value):
+        if name == "iJack":
+            self._iJack = value
+        else:
+            return super().__setattr__(name, value)
+
     def _pre_emit(self):
-        self.add_subordinate_descriptor(MidiOutJackDescriptorFootEmitter())
+        foot = MidiOutJackDescriptorFootEmitter()
+        if hasattr(self, "_iJack"):
+            foot.iJack = self._iJack
+        self.add_subordinate_descriptor(foot)
         # Figure out the total length of our descriptor, including subordinates.
         subordinate_length = sum(len(sub) for sub in self._subordinates)
         self.bLength = subordinate_length + self.DESCRIPTOR_FORMAT.sizeof()


### PR DESCRIPTION
Hi,

`iJack` being part of the footer structure, it isn't currently possible to set its value. This hack lets the user specify their `iJack` value by storing it as a private object member and later using it when building the structure.

Jean