### PR TITLE
Add an emitter for interface association descriptors

### DIFF
--- a/usb_protocol/types/descriptors/partial/standard.py
+++ b/usb_protocol/types/descriptors/partial/standard.py
@@ -2,10 +2,11 @@
 
 from .. import standard
 
-DeviceDescriptor          = standard.DeviceDescriptor.Partial
-ConfigurationDescriptor   = standard.ConfigurationDescriptor.Partial
-StringDescriptor          = standard.StringDescriptor.Partial
-StringLanguageDescriptor  = standard.StringLanguageDescriptor.Partial
-InterfaceDescriptor       = standard.InterfaceDescriptor.Partial
-EndpointDescriptor        = standard.EndpointDescriptor.Partial
-DeviceQualifierDescriptor = standard.DeviceQualifierDescriptor.Partial
+DeviceDescriptor               = standard.DeviceDescriptor.Partial
+ConfigurationDescriptor        = standard.ConfigurationDescriptor.Partial
+StringDescriptor               = standard.StringDescriptor.Partial
+StringLanguageDescriptor       = standard.StringLanguageDescriptor.Partial
+InterfaceDescriptor            = standard.InterfaceDescriptor.Partial
+EndpointDescriptor             = standard.EndpointDescriptor.Partial
+DeviceQualifierDescriptor      = standard.DeviceQualifierDescriptor.Partial
+InterfaceAssociationDescriptor = standard.InterfaceAssociationDescriptor.Partial

--- a/usb_protocol/types/descriptors/standard.py
+++ b/usb_protocol/types/descriptors/standard.py
@@ -171,7 +171,7 @@ InterfaceAssociationDescriptor = DescriptorFormat(
     "bFunctionClass"      / DescriptorField("Class code"),
     "bFunctionSubClass"   / DescriptorField("Subclass code"),
     "bFunctionProtocol"   / DescriptorField("Protocol code"),
-    "iFunction"           / DescriptorField("Index of string descriptor describing this function."),
+    "iFunction"           / DescriptorField("Index of string descriptor describing this function.", default=0),
 )
 
 #


### PR DESCRIPTION
This extends on https://github.com/greatscottgadgets/python-usb-protocol/pull/24 by adding the appropriate emitter so that you can add this descriptor to a configuration descriptor.
I also bundled in a couple of other minor fixes.